### PR TITLE
Replace `UAParser` with `HttpUserAgentParser`

### DIFF
--- a/Helpers/UserAgentHelper.cs
+++ b/Helpers/UserAgentHelper.cs
@@ -1,10 +1,13 @@
-﻿namespace IStillDontCareAboutCookies.Api.Helpers;
+﻿using MyCSharp.HttpUserAgentParser;
+
+namespace IStillDontCareAboutCookies.Api.Helpers;
 public static class UserAgentHelper
 {
     public static string GetBrowser(this IHeaderDictionary headers)
     {
-        var parsed = UAParser.Parser.GetDefault().Parse(headers.UserAgent);
-        return $"{parsed.UA.Family} {parsed.UA.Major}";
-    }
+        string userAgent = headers.UserAgent.ToString();
+        HttpUserAgentInformation parsed = HttpUserAgentParser.Parse(userAgent);
 
+        return $"{parsed.Name} {parsed.Version}";
+    }
 }

--- a/Helpers/UserAgentHelper.cs
+++ b/Helpers/UserAgentHelper.cs
@@ -1,6 +1,7 @@
 ﻿using MyCSharp.HttpUserAgentParser;
 
 namespace IStillDontCareAboutCookies.Api.Helpers;
+
 public static class UserAgentHelper
 {
     public static string GetBrowser(this IHeaderDictionary headers)

--- a/IStillDontCareAboutCookies.Api.csproj
+++ b/IStillDontCareAboutCookies.Api.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Octokit" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="UAParser" Version="3.1.47" />
+    <PackageReference Include="MyCSharp.HttpUserAgentParser" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 </div>
 
-This is the ASP.NET API for the _[I Still Dont Care About Cookies](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies)_ extension. It uses .NET 8.0 as a target framework, and also makes use of [Octokit](https://github.com/octokit/octokit.net), [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) and [UAParser](https://github.com/ua-parser/uap-csharp) as package dependencies. Currently, this API is used for anonymous reports.
+This is the ASP.NET API for the _[I Still Dont Care About Cookies](https://github.com/OhMyGuus/I-Still-Dont-Care-About-Cookies)_ extension. It uses .NET 8.0 as a target framework, and also makes use of [Octokit](https://github.com/octokit/octokit.net), [Swashbuckle](https://github.com/domaindrivendev/Swashbuckle.AspNetCore) and [HttpUserAgentParser](https://github.com/mycsharp/HttpUserAgentParser) as package dependencies. Currently, this API is used for anonymous reports.
 
 ## Building
 ### Linux (Arch)


### PR DESCRIPTION
UAParser has not been updated in 3 years ([see here](https://github.com/ua-parser/uap-csharp)); the package I have added was last updated last month + seems to be a bit faster also.