### PR TITLE
Update GitHub Actions and remove path filter

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -5,9 +5,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'PublishGitHubAction/**'
-  
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -18,15 +16,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.x'
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary
- Update GitHub Actions to latest versions in publish-docker workflow
- Remove path filter to allow workflow to trigger on all main branch changes

## GitHub Actions Updates
- `actions/checkout`: v2 → v4
- `actions/setup-dotnet`: v1 → v4
- `docker/login-action`: v1 → v3

These updates provide better performance, security, and Node.js 20 compatibility.

## Workflow Changes
- Removed paths filter to allow workflow to trigger on all changes to main branch, not just PublishGitHubAction directory
