### PR TITLE
Add automatic HTTPS scheme to URLs without protocol

### DIFF
--- a/Models/ReportModel.cs
+++ b/Models/ReportModel.cs
@@ -31,7 +31,16 @@ public class ReportModel
 
     public Uri? GetUri()
     {
-        return Uri.TryCreate(URL, UriKind.Absolute, out var uri) ? uri : null;
+        var url = URL;
+
+        // Add https:// if no scheme is present
+        if (!url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+            !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            url = "https://" + url;
+        }
+
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri) ? uri : null;
     }
 }
 


### PR DESCRIPTION
## Summary
- Updated `ReportModel.GetUri()` to automatically prepend "https://" to URLs that don't have a scheme
- This ensures proper URI parsing for user-submitted URLs that may be missing the protocol (e.g., "example.com" → "https://example.com")
- Preserves existing http:// and https:// schemes when already present

